### PR TITLE
Fix code scanning alert no. 4: User-controlled bypass of sensitive method

### DIFF
--- a/Source/Microsoft.Teams.Apps.RemoteSupport/Controllers/RemoteSupportController.cs
+++ b/Source/Microsoft.Teams.Apps.RemoteSupport/Controllers/RemoteSupportController.cs
@@ -179,14 +179,14 @@ namespace Microsoft.Teams.Apps.RemoteSupport.Controllers
         {
             try
             {
-                if (onCallSupportDetails == null)
-                {
-                    return this.BadRequest();
-                }
-
                 if (!this.IsUserAuthenticated())
                 {
                     throw new UnauthorizedAccessException("Failed to get fromId from token.");
+                }
+
+                if (onCallSupportDetails == null)
+                {
+                    return this.BadRequest();
                 }
 
                 this.logger.LogInformation("Initiated call to on storage provider service.");


### PR DESCRIPTION
Fixes [https://github.com/Wintellisys/microsoft-teams-apps-incidentreport/security/code-scanning/4](https://github.com/Wintellisys/microsoft-teams-apps-incidentreport/security/code-scanning/4)

To fix the problem, we need to ensure that the authentication check is performed before any other validation or processing of the user-provided data. This will prevent any possibility of bypassing the authentication by manipulating the input.

- Move the `this.IsUserAuthenticated()` check to the beginning of the method, before any other validation or processing.
- Ensure that the authentication check is the first condition to be evaluated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
