### PR TITLE
Fix code scanning alert no. 2: Log entries created from user input

### DIFF
--- a/Source/Microsoft.Teams.Apps.RemoteSupport.Configuration/Controllers/StorageController.cs
+++ b/Source/Microsoft.Teams.Apps.RemoteSupport.Configuration/Controllers/StorageController.cs
@@ -69,11 +69,11 @@ namespace Microsoft.Teams.Apps.RemoteSupport.Configuration
                 var result = await this.configurationStorageProvider.StoreOrUpdateEntityAsync(configurationEntity);
                 if (result == null)
                 {
-                    this.logger.LogInformation("Error in saving configurations " + configurationEntity.CreatedByObjectId);
+                    this.logger.LogInformation("Error in saving configurations " + configurationEntity.CreatedByObjectId.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", ""));
                     return this.StatusCode(StatusCodes.Status500InternalServerError);
                 }
 
-                this.logger.LogInformation("Configurations saved successfully " + configurationEntity.CreatedByObjectId);
+                this.logger.LogInformation("Configurations saved successfully " + configurationEntity.CreatedByObjectId.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", ""));
                 return this.Ok();
             }
             catch (Exception ex)
@@ -94,11 +94,11 @@ namespace Microsoft.Teams.Apps.RemoteSupport.Configuration
             {
                 if (!this.validUsers.Contains(this.HttpContext.User.Identity.Name))
                 {
-                    this.logger.LogInformation("Unauthorized " + this.GetId());
+                    this.logger.LogInformation("Unauthorized " + this.GetId().Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", ""));
                     return this.Unauthorized();
                 }
 
-                this.logger.LogInformation("Get configurations " + this.GetId());
+                this.logger.LogInformation("Get configurations " + this.GetId().Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", ""));
                 var result = await this.configurationStorageProvider.GetConfigurationAsync();
                 return this.Ok(result);
             }


### PR DESCRIPTION
Fixes [https://github.com/Wintellisys/microsoft-teams-apps-incidentreport/security/code-scanning/2](https://github.com/Wintellisys/microsoft-teams-apps-incidentreport/security/code-scanning/2)

To fix the problem, we need to sanitize the `CreatedByObjectId` before logging it. Since the log entries are plain text, we should remove any new line characters from the `CreatedByObjectId` to prevent log forging. This can be done using the `Replace` method to remove new line characters.

1. Identify the lines where `CreatedByObjectId` is logged.
2. Sanitize the `CreatedByObjectId` by removing new line characters before logging.
3. Ensure the changes are minimal and do not affect the existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
