### PR TITLE
Fix code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/Source/Microsoft.Teams.Apps.RemoteSupport.Configuration/ClientApp/src/components/build-form-action.tsx
+++ b/Source/Microsoft.Teams.Apps.RemoteSupport.Configuration/ClientApp/src/components/build-form-action.tsx
@@ -123,7 +123,15 @@ class BuildYourForm extends React.Component<ITeamProps, ITeamState>
             return;
         }
 
-        if (!link.includes("teams.microsoft.com/")) {
+        try {
+            const url = new URL(link);
+            const allowedHosts = ["teams.microsoft.com"];
+            if (!allowedHosts.includes(url.host)) {
+                this.setState({ open: false });
+                this.props.onPublish(false, this.props.resourceStrings.common.invalidTeamLink);
+                return;
+            }
+        } catch (e) {
             this.setState({ open: false });
             this.props.onPublish(false, this.props.resourceStrings.common.invalidTeamLink);
             return;


### PR DESCRIPTION
Fixes [https://github.com/Wintellisys/microsoft-teams-apps-incidentreport/security/code-scanning/5](https://github.com/Wintellisys/microsoft-teams-apps-incidentreport/security/code-scanning/5)

To fix the problem, we need to parse the URL and check its host value against a whitelist of allowed hosts. This ensures that the URL is correctly validated and not susceptible to substring-based attacks.

- Use the `URL` constructor to parse the URL and extract the host.
- Compare the extracted host against a whitelist of allowed hosts.
- Update the `validateUrl` function to implement these changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
